### PR TITLE
Add framework resources path

### DIFF
--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -1,5 +1,6 @@
 public struct Config {
   public static let defaultLocale: String = "en"
   public static var dirPath: String = "Resources/Locales"
+  public static var dirFrameworkPath: String = ""
   public static let pathExtension: String = "json"
 }

--- a/Source/Data/Provider.swift
+++ b/Source/Data/Provider.swift
@@ -12,7 +12,11 @@ public class Provider {
     } else {
       let bundle = NSBundle(forClass: Provider.self)
       var path = bundle.pathForResource(locale, ofType: Config.pathExtension, inDirectory: Config.dirPath)
-
+        
+      if path == nil {
+        path = bundle.pathForResource(locale, ofType: Config.pathExtension, inDirectory: Config.dirFrameworkPath)
+      }
+        
       if let resourcePath = NSBundle(forClass: Provider.self).resourcePath {
         let bundlePath = resourcePath + "/Faker.bundle"
 


### PR DESCRIPTION
This pull request adds support for Fakery import by framework (Carthage).

When Fakery is imported as Fakery.framework all the assets of the project are placed in the root folder, like the example shown below:
<img width="133" alt="screen shot 2015-11-23 at 15 15 51" src="https://cloud.githubusercontent.com/assets/8330387/11340369/8a768e52-91f5-11e5-8a4b-d6167ffcd7d5.png">

With this change Fakery will find for the `json` resources on the root folder and at the `Resources/Locales` folder. This will add support for both CocoaPods and Carthage.
 