### PR TITLE
Fix error in randomInt with large Ints

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v5.0.0"
+github "Quick/Nimble" "v5.1.0"
 github "Quick/Quick" "v0.10.0"

--- a/Source/Generators/Number.swift
+++ b/Source/Generators/Number.swift
@@ -17,6 +17,11 @@ public final class Number {
 
     i = i & Int.max // Make the number positive
 
+    if max >= 0 && max - Int.max >= min {
+        return min + i
+    }
+
+
     return min + (i % (max - min))
 
   }

--- a/Source/Generators/Number.swift
+++ b/Source/Generators/Number.swift
@@ -10,7 +10,15 @@ public final class Number {
   }
 
   public func randomInt(min: Int = 0, max: Int = 1000) -> Int {
-    return min + Int(arc4random_uniform(UInt32(max - min + 1)))
+
+    var i: Int = 0
+
+    arc4random_buf(&i, MemoryLayout.size(ofValue: i))
+
+    i = i & Int.max // Make the number positive
+
+    return min + (i % (max - min))
+
   }
 
   public func randomFloat(min: Float = 0, max: Float = 1000) -> Float {

--- a/Tests/Fakery/Generators/NumberSpec.swift
+++ b/Tests/Fakery/Generators/NumberSpec.swift
@@ -30,6 +30,13 @@ class NumberSpec: QuickSpec {
 
         expect(number.randomInt(min: 1000000000000, max: 9999999999999)) >= 1000000000000
         expect(number.randomInt(min: 1000000000000, max: 9999999999999)) <= 9999999999999
+
+        expect(number.randomInt(min: Int.min, max: Int.max)) >= Int.min
+        expect(number.randomInt(min: Int.min, max: Int.max)) <= Int.max
+
+        expect(number.randomInt(min: Int.min, max: 0)) >= Int.min
+        expect(number.randomInt(min: Int.min, max: 0)) <= 0
+
       }
 
       it("creates random Floats") {

--- a/Tests/Fakery/Generators/NumberSpec.swift
+++ b/Tests/Fakery/Generators/NumberSpec.swift
@@ -27,6 +27,9 @@ class NumberSpec: QuickSpec {
 
         expect(number.randomInt(min:5, max:7)) <= 7
         expect(number.randomInt(min:5, max:7)) >= 5
+
+        expect(number.randomInt(min: 1000000000000, max: 9999999999999)) >= 1000000000000
+        expect(number.randomInt(min: 1000000000000, max: 9999999999999)) <= 9999999999999
       }
 
       it("creates random Floats") {


### PR DESCRIPTION
The initialisation of the `UInt32` in `randomInt` failed, when `max - min + 1` was bigger than `UInt32.max`.
This can happen because `Int` is a `Int64` on 64-bit systems.

I replaced `arc4random_uniform` with `arc4random_buf` which just fills the `Int` with random bits.

To transform the random number to a positive one, I used `& Int.max` to set the first bit to `0` (which is faster than `abs()`)