### PR TITLE
tvOS & macOS Podspec Changes

### DIFF
--- a/Fakery.podspec
+++ b/Fakery.podspec
@@ -19,7 +19,8 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/vadymmarkov'
 
   s.ios.deployment_target = "8.0"
-  s.osx.deployment_target = "10.10"
+  s.osx.deployment_target = "10.9"
+  s.tvos.deployment_target = "9.0"
   s.requires_arc = true
 
   s.resource_bundles = {


### PR DESCRIPTION
This PR changes the minimum macOS version in Podspec to 10.9 (as per #60), as well as adding a tvOS (9.0) deployment target in there.