### PR TITLE
User should be able to specify the resource directory

### DIFF
--- a/Sources/Fakery/Config.swift
+++ b/Sources/Fakery/Config.swift
@@ -3,4 +3,5 @@ public struct Config {
   public static let pathExtension: String = "json"
   public static var dirPath: String = "Resources/Locales"
   public static var dirFrameworkPath: String = ""
+  public static var dirResourcePath: String = ""
 }

--- a/Sources/Fakery/Data/Provider.swift
+++ b/Sources/Fakery/Data/Provider.swift
@@ -15,13 +15,13 @@ public final class Provider {
       
       var path = bundle.path(forResource: locale,
                              ofType: Config.pathExtension,
+                             inDirectory: Config.dirResourcePath) ??
+                 bundle.path(forResource: locale,
+                             ofType: Config.pathExtension,
                              inDirectory: Config.dirPath) ??
                  bundle.path(forResource: locale,
                              ofType: Config.pathExtension,
-                             inDirectory: Config.dirFrameworkPath) ??
-                 bundle.path(forResource: locale,
-                             ofType: Config.pathExtension,
-                             inDirectory: Config.dirResourcePath)
+                             inDirectory: Config.dirFrameworkPath)
 
       if let resourcePath = Bundle(for: Provider.self).resourcePath {
         let bundlePath = resourcePath + "/Faker.bundle"

--- a/Sources/Fakery/Data/Provider.swift
+++ b/Sources/Fakery/Data/Provider.swift
@@ -15,13 +15,14 @@ public final class Provider {
       
       var path = bundle.path(forResource: locale,
                              ofType: Config.pathExtension,
-                             inDirectory: Config.dirResourcePath) ??
-                 bundle.path(forResource: locale,
-                             ofType: Config.pathExtension,
                              inDirectory: Config.dirPath) ??
                  bundle.path(forResource: locale,
                              ofType: Config.pathExtension,
                              inDirectory: Config.dirFrameworkPath)
+
+      if !Config.dirResourcePath.isEmpty {
+        path = "\(Config.dirResourcePath)/\(locale).\(Config.pathExtension)"
+      }
 
       if let resourcePath = Bundle(for: Provider.self).resourcePath {
         let bundlePath = resourcePath + "/Faker.bundle"

--- a/Sources/Fakery/Data/Provider.swift
+++ b/Sources/Fakery/Data/Provider.swift
@@ -12,15 +12,16 @@ public final class Provider {
       translation = translationData
     } else {
       let bundle = Bundle(for: Provider.self)
+      
       var path = bundle.path(forResource: locale,
                              ofType: Config.pathExtension,
-                             inDirectory: Config.dirPath)
-
-      if path == nil {
-        path = bundle.path(forResource: locale,
-                           ofType: Config.pathExtension,
-                           inDirectory: Config.dirFrameworkPath)
-      }
+                             inDirectory: Config.dirPath) ??
+                 bundle.path(forResource: locale,
+                             ofType: Config.pathExtension,
+                             inDirectory: Config.dirFrameworkPath) ??
+                 bundle.path(forResource: locale,
+                             ofType: Config.pathExtension,
+                             inDirectory: Config.dirResourcePath)
 
       if let resourcePath = Bundle(for: Provider.self).resourcePath {
         let bundlePath = resourcePath + "/Faker.bundle"


### PR DESCRIPTION
In instances, such as using Swift Package Manager, the resources directory is ignored. That means that resources must be manually manipulated, so the developer needs to be able to specify where the localization files can be found.