### PR TITLE
Move all generators into namespace Faker

### DIFF
--- a/Sources/Fakery/Generators/Address.swift
+++ b/Sources/Fakery/Generators/Address.swift
@@ -9,113 +9,115 @@ import CoreLocation
 public typealias Location = CLLocationCoordinate2D
 #endif
 
-public final class Address: Generator {
-  public func city() -> String {
-    return generate("address.city")
-  }
-
-  public func streetName() -> String {
-    return generate("address.street_name")
-  }
-
-  public func secondaryAddress() -> String {
-    return numerify(generate("address.secondary_address"))
-  }
-
-  public func streetAddress(includeSecondary: Bool = false) -> String {
-    var streetAddress = numerify(generate("address.street_address"))
-
-    if includeSecondary {
-      streetAddress += " " + secondaryAddress()
+extension Faker {
+  public final class Address: Generator {
+    public func city() -> String {
+      return generate("address.city")
     }
 
-    return streetAddress
-  }
-
-  public func buildingNumber() -> String {
-    return bothify(generate("address.building_number"))
-  }
-
-  public func postcode(stateAbbreviation: String = "") -> String {
-    if stateAbbreviation.isEmpty {
-      return bothify(generate("address.postcode"))
+    public func streetName() -> String {
+      return generate("address.street_name")
     }
 
-    return bothify(generate("address.postcode_by_state.\(stateAbbreviation)"))
-  }
+    public func secondaryAddress() -> String {
+      return numerify(generate("address.secondary_address"))
+    }
 
-  public func timeZone() -> String {
-    return generate("address.time_zone")
-  }
+    public func streetAddress(includeSecondary: Bool = false) -> String {
+      var streetAddress = numerify(generate("address.street_address"))
 
-  public func streetSuffix() -> String {
-    return generate("address.street_suffix")
-  }
+      if includeSecondary {
+        streetAddress += " " + secondaryAddress()
+      }
 
-  public func citySuffix() -> String {
-    return generate("address.city_suffix")
-  }
+      return streetAddress
+    }
 
-  public func cityPrefix() -> String {
-    return generate("address.city_prefix")
-  }
+    public func buildingNumber() -> String {
+      return bothify(generate("address.building_number"))
+    }
 
-  public func stateAbbreviation() -> String {
-    return generate("address.state_abbr")
-  }
+    public func postcode(stateAbbreviation: String = "") -> String {
+      if stateAbbreviation.isEmpty {
+        return bothify(generate("address.postcode"))
+      }
 
-  public func state() -> String {
-    return generate("address.state")
-  }
+      return bothify(generate("address.postcode_by_state.\(stateAbbreviation)"))
+    }
 
-  public func county() -> String {
-    return generate("address.county")
-  }
+    public func timeZone() -> String {
+      return generate("address.time_zone")
+    }
 
-  public func country() -> String {
-    return generate("address.country")
-  }
+    public func streetSuffix() -> String {
+      return generate("address.street_suffix")
+    }
 
-  public func countryCode() -> String {
-    return generate("address.country_code")
-  }
+    public func citySuffix() -> String {
+      return generate("address.city_suffix")
+    }
 
-  public func latitude() -> Double {
-    return drand48() * 180.0 - 90.0
-  }
+    public func cityPrefix() -> String {
+      return generate("address.city_prefix")
+    }
 
-  public func longitude() -> Double {
-    return drand48() * 360.0 - 180.0
-  }
-  
-  public func coordinate(inRadius radius: Double, fromCenter center: Location) -> Location {
-    let y0 = center.latitude
-    let x0 = center.longitude
-    
-    // Convert meters to degrees for radius
-    let radiusInDegrees = radius / 111300.0
-    
-    // Random point in circle
-    #if swift(>=4.2)
-    let u = Double.random(in: 0..<Double.greatestFiniteMagnitude) / 0xFFFFFFFF
-    let v = Double.random(in: 0..<Double.greatestFiniteMagnitude) / 0xFFFFFFFF
-    #else
-    let u = Double(arc4random()) / 0xFFFFFFFF
-    let v = Double(arc4random()) / 0xFFFFFFFF
-    #endif
-    let w = radiusInDegrees * sqrt(u)
-    let t = 2 * .pi * v
-    let x = w * cos(t)
-    let y = w * sin(t)
-    
-    // Adjust longitude (x) to adjust for east-west shrinking in distance
-    let latRadians = y0 * .pi / 180
-    let newx = x / cos(latRadians)
-    
-    // Set found random point
-    let foundLatitude = y + y0
-    let foundLongitude = newx + x0
-    
-    return Location(latitude: foundLatitude, longitude: foundLongitude)
+    public func stateAbbreviation() -> String {
+      return generate("address.state_abbr")
+    }
+
+    public func state() -> String {
+      return generate("address.state")
+    }
+
+    public func county() -> String {
+      return generate("address.county")
+    }
+
+    public func country() -> String {
+      return generate("address.country")
+    }
+
+    public func countryCode() -> String {
+      return generate("address.country_code")
+    }
+
+    public func latitude() -> Double {
+      return drand48() * 180.0 - 90.0
+    }
+
+    public func longitude() -> Double {
+      return drand48() * 360.0 - 180.0
+    }
+
+    public func coordinate(inRadius radius: Double, fromCenter center: Location) -> Location {
+      let y0 = center.latitude
+      let x0 = center.longitude
+
+      // Convert meters to degrees for radius
+      let radiusInDegrees = radius / 111300.0
+
+      // Random point in circle
+      #if swift(>=4.2)
+      let u = Double.random(in: 0..<Double.greatestFiniteMagnitude) / 0xFFFFFFFF
+      let v = Double.random(in: 0..<Double.greatestFiniteMagnitude) / 0xFFFFFFFF
+      #else
+      let u = Double(arc4random()) / 0xFFFFFFFF
+      let v = Double(arc4random()) / 0xFFFFFFFF
+      #endif
+      let w = radiusInDegrees * sqrt(u)
+      let t = 2 * .pi * v
+      let x = w * cos(t)
+      let y = w * sin(t)
+
+      // Adjust longitude (x) to adjust for east-west shrinking in distance
+      let latRadians = y0 * .pi / 180
+      let newx = x / cos(latRadians)
+
+      // Set found random point
+      let foundLatitude = y + y0
+      let foundLongitude = newx + x0
+
+      return Location(latitude: foundLatitude, longitude: foundLongitude)
+    }
   }
 }

--- a/Sources/Fakery/Generators/App.swift
+++ b/Sources/Fakery/Generators/App.swift
@@ -1,13 +1,15 @@
-public final class App: Generator {
-  public func name() -> String {
-    return generate("app.name")
-  }
+extension Faker {
+  public final class App: Generator {
+    public func name() -> String {
+      return generate("app.name")
+    }
 
-  public func version() -> String {
-    return numerify(generate("app.version"))
-  }
+    public func version() -> String {
+      return numerify(generate("app.version"))
+    }
 
-  public func author() -> String {
-    return generate("app.author")
+    public func author() -> String {
+      return generate("app.author")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Bank.swift
+++ b/Sources/Fakery/Generators/Bank.swift
@@ -1,25 +1,27 @@
-public final class Bank: Generator {
-  public func name() -> String {
-    return generate("bank.name")
-  }
+extension Faker {
+  public final class Bank: Generator {
+    public func name() -> String {
+      return generate("bank.name")
+    }
 
-  public func swiftBic() -> String {
-    return generate("bank.swiftBic")
-  }
+    public func swiftBic() -> String {
+      return generate("bank.swiftBic")
+    }
 
-  public func iban() -> String {
-    let bankCountryCode = generate("bank.ibanDetails.bankCountryCode")
-    let bankCountryString = numerify("##")
-    let ibanLetterCode = letterify(generate("bank.ibanDetails.ibanLetterCode"))
-    let iban = numerify(generate("bank.ibanDetails.ibanDigits"))
+    public func iban() -> String {
+      let bankCountryCode = generate("bank.ibanDetails.bankCountryCode")
+      let bankCountryString = numerify("##")
+      let ibanLetterCode = letterify(generate("bank.ibanDetails.ibanLetterCode"))
+      let iban = numerify(generate("bank.ibanDetails.ibanDigits"))
 
-    return bankCountryCode + bankCountryString + ibanLetterCode + iban
-  }
+      return bankCountryCode + bankCountryString + ibanLetterCode + iban
+    }
 
-  public func bban() -> String {
-    let ibanLetterCode: String = letterify(generate("bank.ibanDetails.ibanLetterCode"))
-    let iban: String  = numerify(generate("bank.ibanDetails.ibanDigits"))
+    public func bban() -> String {
+      let ibanLetterCode: String = letterify(generate("bank.ibanDetails.ibanLetterCode"))
+      let iban: String = numerify(generate("bank.ibanDetails.ibanDigits"))
 
-    return ibanLetterCode + iban
+      return ibanLetterCode + iban
+    }
   }
 }

--- a/Sources/Fakery/Generators/Business.swift
+++ b/Sources/Fakery/Generators/Business.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-public final class Business: Generator {
-  public func creditCardNumber() -> String {
-    return generate("business.credit_card_numbers")
-  }
+extension Faker {
+  public final class Business: Generator {
+    public func creditCardNumber() -> String {
+      return generate("business.credit_card_numbers")
+    }
 
-  public func creditCardType() -> String {
-    return generate("business.credit_card_types")
-  }
+    public func creditCardType() -> String {
+      return generate("business.credit_card_types")
+    }
 
-  public func creditCardExpiryDate() -> Foundation.Date? {
-    let dateString = generate("business.credit_card_expiry_dates")
-    return dateFormatter.date(from: dateString)
+    public func creditCardExpiryDate() -> Foundation.Date? {
+      let dateString = generate("business.credit_card_expiry_dates")
+      return dateFormatter.date(from: dateString)
+    }
   }
 }

--- a/Sources/Fakery/Generators/Car.swift
+++ b/Sources/Fakery/Generators/Car.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-public final class Car: Generator {
-  public func brand() -> String {
-    return generate("car.brand")
+extension Faker {
+  public final class Car: Generator {
+    public func brand() -> String {
+      return generate("car.brand")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Cat.swift
+++ b/Sources/Fakery/Generators/Cat.swift
@@ -1,15 +1,17 @@
 import Foundation
 
-public final class Cat: Generator {
-  public func name() -> String {
-    return generate("cat.name")
-  }
+extension Faker {
+  public final class Cat: Generator {
+    public func name() -> String {
+      return generate("cat.name")
+    }
 
-  public func breed() -> String {
-    return generate("cat.breed")
-  }
+    public func breed() -> String {
+      return generate("cat.breed")
+    }
 
-  public func registry() -> String {
-    return generate("cat.registry")
+    public func registry() -> String {
+      return generate("cat.registry")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Commerce.swift
+++ b/Sources/Fakery/Generators/Commerce.swift
@@ -1,65 +1,67 @@
 import Foundation
 
-public final class Commerce: Generator {
-  public func color() -> String {
-    return generate("commerce.color")
-  }
-
-  public func department(maximum: Int = 3, fixedAmount: Bool = false) -> String {
-    #if swift(>=4.2)
-    let amount = fixedAmount ? maximum : 1 + Int.random(in: 0..<maximum)
-    #else
-    let amount = fixedAmount ? maximum : 1 + Int(arc4random_uniform(UInt32(maximum)))
-    #endif
-    let fetchedCategories = categories(amount)
-    let count = fetchedCategories.count
-
-    var department = ""
-
-    if count > 1 {
-      department = merge(categories: fetchedCategories)
-    } else if count == 1 {
-      department = fetchedCategories[0]
+extension Faker {
+  public final class Commerce: Generator {
+    public func color() -> String {
+      return generate("commerce.color")
     }
 
-    return department
-  }
+    public func department(maximum: Int = 3, fixedAmount: Bool = false) -> String {
+      #if swift(>=4.2)
+      let amount = fixedAmount ? maximum : 1 + Int.random(in: 0..<maximum)
+      #else
+      let amount = fixedAmount ? maximum : 1 + Int(arc4random_uniform(UInt32(maximum)))
+      #endif
+      let fetchedCategories = categories(amount)
+      let count = fetchedCategories.count
 
-  public func productName() -> String {
-    return generate("commerce.product_name.adjective") + " "
-      + generate("commerce.product_name.material") + " "
-      + generate("commerce.product_name.product")
-  }
+      var department = ""
 
-  public func price() -> Double {
-    let arc4randoMax: Double = 0x100000000
-    #if swift(>=4.2)
-    return floor(Double((Double(UInt32.random(in: 0..<UInt32.max)) / arc4randoMax) * 100.0) * 100) / 100.0
-    #else
-    return floor(Double((Double(arc4random()) / arc4randoMax) * 100.0) * 100) / 100.0
-    #endif
-  }
-
-  // MARK: - Helpers
-
-  public func categories(_ amount: Int) -> [String] {
-    var categories: [String] = []
-
-    while categories.count < amount {
-      let category = generate("commerce.department")
-
-      if !categories.contains(category) {
-        categories.append(category)
+      if count > 1 {
+        department = merge(categories: fetchedCategories)
+      } else if count == 1 {
+        department = fetchedCategories[0]
       }
+
+      return department
     }
 
-    return categories
-  }
+    public func productName() -> String {
+      return generate("commerce.product_name.adjective") + " "
+          + generate("commerce.product_name.material") + " "
+          + generate("commerce.product_name.product")
+    }
 
-  public func merge(categories: [String]) -> String {
-    let separator = generate("separator")
-    let commaSeparated = categories[0..<categories.count - 1].joined(separator: ", ")
+    public func price() -> Double {
+      let arc4randoMax: Double = 0x100000000
+      #if swift(>=4.2)
+      return floor(Double((Double(UInt32.random(in: 0..<UInt32.max)) / arc4randoMax) * 100.0) * 100) / 100.0
+      #else
+      return floor(Double((Double(arc4random()) / arc4randoMax) * 100.0) * 100) / 100.0
+      #endif
+    }
 
-    return commaSeparated + separator + categories.last!
+    // MARK: - Helpers
+
+    public func categories(_ amount: Int) -> [String] {
+      var categories: [String] = []
+
+      while categories.count < amount {
+        let category = generate("commerce.department")
+
+        if !categories.contains(category) {
+          categories.append(category)
+        }
+      }
+
+      return categories
+    }
+
+    public func merge(categories: [String]) -> String {
+      let separator = generate("separator")
+      let commaSeparated = categories[0..<categories.count - 1].joined(separator: ", ")
+
+      return commaSeparated + separator + categories.last!
+    }
   }
 }

--- a/Sources/Fakery/Generators/Company.swift
+++ b/Sources/Fakery/Generators/Company.swift
@@ -1,28 +1,30 @@
 import Foundation
 
-public final class Company: Generator {
-  public func name() -> String {
-    return generate("company.name")
-  }
+extension Faker {
+  public final class Company: Generator {
+    public func name() -> String {
+      return generate("company.name")
+    }
 
-  public func suffix() -> String {
-    return generate("company.suffix")
-  }
+    public func suffix() -> String {
+      return generate("company.suffix")
+    }
 
-  public func catchPhrase() -> String {
-    return randomWordsFromKey("company.buzzwords")
-  }
+    public func catchPhrase() -> String {
+      return randomWordsFromKey("company.buzzwords")
+    }
 
-  public func bs() -> String {
-    return randomWordsFromKey("company.bs")
-  }
+    public func bs() -> String {
+      return randomWordsFromKey("company.bs")
+    }
 
-  public func logo() -> String {
-    #if swift(>=4.2)
-     let number = Int.random(in: 0..<13) + 1
-    #else
-     let number = Int(arc4random_uniform(13)) + 1
-    #endif
-    return "https://pigment.github.io/fake-logos/logos/medium/color/\(number).png"
+    public func logo() -> String {
+      #if swift(>=4.2)
+      let number = Int.random(in: 0..<13) + 1
+      #else
+      let number = Int(arc4random_uniform(13)) + 1
+      #endif
+      return "https://pigment.github.io/fake-logos/logos/medium/color/\(number).png"
+    }
   }
 }

--- a/Sources/Fakery/Generators/Date.swift
+++ b/Sources/Fakery/Generators/Date.swift
@@ -1,43 +1,45 @@
 import Foundation
 
-public final class Date {
-  public func backward(days: Int) -> Foundation.Date {
-    return todayAddingDays(-days)
-  }
+extension Faker {
+  public final class Date {
+    public func backward(days: Int) -> Foundation.Date {
+      return todayAddingDays(-days)
+    }
 
-  public func forward(_ days: Int) -> Foundation.Date {
-    return todayAddingDays(days)
-  }
+    public func forward(_ days: Int) -> Foundation.Date {
+      return todayAddingDays(days)
+    }
 
-  public func between(_ from: Foundation.Date, _ to: Foundation.Date) -> Foundation.Date {
-    let fromInSeconds = from.timeIntervalSince1970
-    let toInSeconds = to.timeIntervalSince1970
-    let targetInSeconds = Number().randomDouble(min: fromInSeconds, max: toInSeconds)
-    return Foundation.Date(timeIntervalSince1970: targetInSeconds)
-  }
+    public func between(_ from: Foundation.Date, _ to: Foundation.Date) -> Foundation.Date {
+      let fromInSeconds = from.timeIntervalSince1970
+      let toInSeconds = to.timeIntervalSince1970
+      let targetInSeconds = Number().randomDouble(min: fromInSeconds, max: toInSeconds)
+      return Foundation.Date(timeIntervalSince1970: targetInSeconds)
+    }
 
-  public func birthday(_ minAge: Int, _ maxAge: Int) -> Foundation.Date {
-    let olderAgeBirthDate = todayAddingYears(-maxAge)
-    let earlierAgeBirthDate = todayAddingYears(-minAge)
-    return between(earlierAgeBirthDate, olderAgeBirthDate)
-  }
+    public func birthday(_ minAge: Int, _ maxAge: Int) -> Foundation.Date {
+      let olderAgeBirthDate = todayAddingYears(-maxAge)
+      let earlierAgeBirthDate = todayAddingYears(-minAge)
+      return between(earlierAgeBirthDate, olderAgeBirthDate)
+    }
 
-  private func todayAddingDays(_ days: Int) -> Foundation.Date {
-    var dateComponents = DateComponents()
-    dateComponents.day = days
-    return todayAdding(dateComponents)
-  }
+    private func todayAddingDays(_ days: Int) -> Foundation.Date {
+      var dateComponents = DateComponents()
+      dateComponents.day = days
+      return todayAdding(dateComponents)
+    }
 
-  private func todayAddingYears(_ years: Int) -> Foundation.Date {
-    var dateComponents = DateComponents()
-    dateComponents.year = years
-    return todayAdding(dateComponents)
-  }
+    private func todayAddingYears(_ years: Int) -> Foundation.Date {
+      var dateComponents = DateComponents()
+      dateComponents.year = years
+      return todayAdding(dateComponents)
+    }
 
-  private func todayAdding(_ dateComponents: DateComponents) -> Foundation.Date {
-    let calendar = Calendar.current
+    private func todayAdding(_ dateComponents: DateComponents) -> Foundation.Date {
+      let calendar = Calendar.current
 
-    let todayDate = Foundation.Date()
-    return calendar.date(byAdding: dateComponents, to: todayDate)!
+      let todayDate = Foundation.Date()
+      return calendar.date(byAdding: dateComponents, to: todayDate)!
+    }
   }
 }

--- a/Sources/Fakery/Generators/Gender.swift
+++ b/Sources/Fakery/Generators/Gender.swift
@@ -1,11 +1,13 @@
 import Foundation
 
-public final class Gender: Generator {
-  public func type() -> String {
-    return generate("gender.type")
-  }
-  
-  public func binaryType() -> String {
-    return generate("gender.binary_type")
+extension Faker {
+  public final class Gender: Generator {
+    public func type() -> String {
+      return generate("gender.type")
+    }
+
+    public func binaryType() -> String {
+      return generate("gender.binary_type")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Generator.swift
+++ b/Sources/Fakery/Generators/Generator.swift
@@ -1,78 +1,80 @@
 import Foundation
 
-public class Generator {
-  public struct Constants {
-    public static let uppercaseLetters = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    public static let letters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    public static let numbers = Array("0123456789")
-  }
-
-  let parser: Parser
-  let dateFormatter: DateFormatter
-
-  public required init(parser: Parser) {
-    self.parser = parser
-    dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd"
-  }
-
-  public func generate(_ key: String) -> String {
-    return parser.fetch(key)
-  }
-
-  // MARK: - Filling
-
-  public func numerify(_ string: String) -> String {
-    let count = UInt32(Constants.numbers.count)
-
-    return String(string.enumerated().map { (index, item) in
-      #if swift(>=4.2)
-      let numberIndex = index == 0 ? UInt32.random(in: 0..<(count - 1)) : UInt32.random(in: 0..<count)
-      #else
-      let numberIndex = index == 0 ? arc4random_uniform(count - 1) : arc4random_uniform(count)
-      #endif
-      let char = Constants.numbers[Int(numberIndex)]
-      return String(item) == "#" ? char : item
-      })
-  }
-
-  public func letterify(_ string: String) -> String {
-    return String(string.enumerated().map { _, item in
-      #if swift(>=4.2)
-      let char = Constants.uppercaseLetters.randomElement() ?? Character("")
-      #else
-      let count = UInt32(Constants.uppercaseLetters.count)
-      let char = Constants.uppercaseLetters[Int(arc4random_uniform(count))]
-      #endif
-      return String(item) == "?" ? char : item
-      })
-  }
-
-  public func bothify(_ string: String) -> String {
-    return letterify(numerify(string))
-  }
-
-  public func alphaNumerify(_ string: String) -> String {
-    return string.replacingOccurrences(of: "[^A-Za-z0-9_]",
-      with: "",
-      options: .regularExpression,
-      range: nil)
-  }
-
-  public func randomWordsFromKey(_ key: String) -> String {
-    var string = ""
-
-    var list = [String]()
-    if let wordsList = parser.fetchRaw(key) as? [[String]] {
-      for words in wordsList {
-        if let item = words.random() {
-          list.append(item)
-        }
-      }
-
-      string = list.joined(separator: " ")
+extension Faker {
+  public class Generator {
+    public struct Constants {
+      public static let uppercaseLetters = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+      public static let letters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+      public static let numbers = Array("0123456789")
     }
 
-    return string
+    let parser: Parser
+    let dateFormatter: DateFormatter
+
+    public required init(parser: Parser) {
+      self.parser = parser
+      dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd"
+    }
+
+    public func generate(_ key: String) -> String {
+      return parser.fetch(key)
+    }
+
+    // MARK: - Filling
+
+    public func numerify(_ string: String) -> String {
+      let count = UInt32(Constants.numbers.count)
+
+      return String(string.enumerated().map { (index, item) in
+        #if swift(>=4.2)
+        let numberIndex = index == 0 ? UInt32.random(in: 0..<(count - 1)) : UInt32.random(in: 0..<count)
+        #else
+        let numberIndex = index == 0 ? arc4random_uniform(count - 1) : arc4random_uniform(count)
+        #endif
+        let char = Constants.numbers[Int(numberIndex)]
+        return String(item) == "#" ? char : item
+      })
+    }
+
+    public func letterify(_ string: String) -> String {
+      return String(string.enumerated().map { _, item in
+        #if swift(>=4.2)
+        let char = Constants.uppercaseLetters.randomElement() ?? Character("")
+        #else
+        let count = UInt32(Constants.uppercaseLetters.count)
+        let char = Constants.uppercaseLetters[Int(arc4random_uniform(count))]
+        #endif
+        return String(item) == "?" ? char : item
+      })
+    }
+
+    public func bothify(_ string: String) -> String {
+      return letterify(numerify(string))
+    }
+
+    public func alphaNumerify(_ string: String) -> String {
+      return string.replacingOccurrences(of: "[^A-Za-z0-9_]",
+                                         with: "",
+                                         options: .regularExpression,
+                                         range: nil)
+    }
+
+    public func randomWordsFromKey(_ key: String) -> String {
+      var string = ""
+
+      var list = [String]()
+      if let wordsList = parser.fetchRaw(key) as? [[String]] {
+        for words in wordsList {
+          if let item = words.random() {
+            list.append(item)
+          }
+        }
+
+        string = list.joined(separator: " ")
+      }
+
+      return string
+    }
   }
 }

--- a/Sources/Fakery/Generators/Ham.swift
+++ b/Sources/Fakery/Generators/Ham.swift
@@ -1,5 +1,7 @@
-public final class Ham: Generator {
-  public func name() -> String {
-    return generate("ham.name")
+extension Faker {
+  public final class Ham: Generator {
+    public func name() -> String {
+      return generate("ham.name")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Internet.swift
+++ b/Sources/Fakery/Generators/Internet.swift
@@ -1,146 +1,148 @@
 import Foundation
 
-public final class Internet: Generator {
-  private let lorem: Lorem
+extension Faker {
+  public final class Internet: Generator {
+    private let lorem: Lorem
 
-  public required init(parser: Parser) {
-    self.lorem = Lorem(parser: parser)
-    super.init(parser: parser)
-  }
-
-  public func username(separator: String? = nil) -> String {
-    #if swift(>=4.2)
-    let lastRandomComponent = Int.random(in: 0..<10000)
-    #else
-    let lastRandomComponent = arc4random_uniform(10000)
-    #endif
-    var components: [String] = [
-      generate("name.first_name"),
-      generate("name.last_name"),
-      "\(lastRandomComponent)"
-    ]
-
-    let randomCount = components.count - 1
-    #if swift(>=4.2)
-    let count = Int.random(in: 0..<randomCount) + randomCount
-    #else
-    let count = Int(arc4random_uniform(UInt32(randomCount)) + UInt32(randomCount))
-    #endif
-
-    var gap = ""
-    if let sep = separator {
-      gap = sep
+    public required init(parser: Parser) {
+      self.lorem = Lorem(parser: parser)
+      super.init(parser: parser)
     }
 
-    return components[0..<count].joined(separator: gap)
-      .replacingOccurrences(of: "'", with: "")
-      .lowercased()
-  }
-
-  public func domainName(_ alphaNumericOnly: Bool = true) -> String {
-    return domainWord(alphaNumericOnly: alphaNumericOnly) + "." + domainSuffix()
-  }
-
-  public func domainWord(alphaNumericOnly: Bool = true) -> String {
-    let nameParts = generate("company.name").components(separatedBy: " ")
-    var name = ""
-
-    if let first = nameParts.first {
-      name = first
-    } else {
-      name = letterify("?????")
-    }
-
-    let result = alphaNumericOnly ? alphaNumerify(name) : name
-
-    return result.lowercased()
-  }
-
-  public func domainSuffix() -> String {
-    return generate("internet.domain_suffix")
-  }
-
-  public func email() -> String {
-    return [username(), domainName()].joined(separator: "@")
-  }
-
-  public func freeEmail() -> String {
-    return [username(), generate("internet.free_email")].joined(separator: "@")
-  }
-
-  public func safeEmail() -> String {
-    let topLevelDomains = ["org", "com", "net"]
-    #if swift(>=4.2)
-    let topLevelDomain = topLevelDomains.randomElement() ?? ""
-    #else
-    let count = UInt32(topLevelDomains.count)
-    let topLevelDomain = topLevelDomains[Int(arc4random_uniform(count))]
-    #endif
-
-    return [username(), "example." + topLevelDomain].joined(separator: "@")
-  }
-
-  public func password(minimumLength: Int = 8, maximumLength: Int = 16) -> String {
-    var temp = lorem.characters(amount: minimumLength)
-    let diffLength = maximumLength - minimumLength
-
-    if diffLength > 0 {
+    public func username(separator: String? = nil) -> String {
       #if swift(>=4.2)
-      let diffRandom = Int.random(in: 0..<diffLength + 1)
+      let lastRandomComponent = Int.random(in: 0..<10000)
       #else
-      let diffRandom = Int(arc4random_uniform(UInt32(diffLength + 1)))
+      let lastRandomComponent = arc4random_uniform(10000)
       #endif
-      temp += lorem.characters(amount: diffRandom)
+      var components: [String] = [
+        generate("name.first_name"),
+        generate("name.last_name"),
+        "\(lastRandomComponent)"
+      ]
+
+      let randomCount = components.count - 1
+      #if swift(>=4.2)
+      let count = Int.random(in: 0..<randomCount) + randomCount
+      #else
+      let count = Int(arc4random_uniform(UInt32(randomCount)) + UInt32(randomCount))
+      #endif
+
+      var gap = ""
+      if let sep = separator {
+        gap = sep
+      }
+
+      return components[0..<count].joined(separator: gap)
+                                  .replacingOccurrences(of: "'", with: "")
+                                  .lowercased()
     }
 
-    return temp
-  }
-
-  public func ipV4Address() -> String {
-    #if swift(>=4.2)
-    let randomNumber = UInt32.random(in: 0..<UInt32.max) % 253
-    #else
-    let randomNumber = arc4random() % 253
-    #endif
-    let ipRand = {
-      2 + randomNumber
+    public func domainName(_ alphaNumericOnly: Bool = true) -> String {
+      return domainWord(alphaNumericOnly: alphaNumericOnly) + "." + domainSuffix()
     }
 
-    return String(format: "%d.%d.%d.%d", ipRand(), ipRand(), ipRand(), ipRand())
-  }
+    public func domainWord(alphaNumericOnly: Bool = true) -> String {
+      let nameParts = generate("company.name").components(separatedBy: " ")
+      var name = ""
 
-  public func ipV6Address() -> String {
-    #if swift(>=4.2)
-    let randomNumber = UInt32.random(in: 0..<UInt32.max) % 65536
-    #else
-    let randomNumber = arc4random() % 65536
-    #endif
+      if let first = nameParts.first {
+        name = first
+      } else {
+        name = letterify("?????")
+      }
 
-    var components: [String] = []
+      let result = alphaNumericOnly ? alphaNumerify(name) : name
 
-    for _ in 0..<8 {
-      components.append(String(format: "%X", randomNumber))
+      return result.lowercased()
     }
 
-    return components.joined(separator: ":")
-  }
+    public func domainSuffix() -> String {
+      return generate("internet.domain_suffix")
+    }
 
-  public func url() -> String {
-    return "https://\(domainName())/\(username())"
-  }
+    public func email() -> String {
+      return [username(), domainName()].joined(separator: "@")
+    }
 
-  public func image(width: Int = 320, height: Int = 200) -> String {
-    return "https://lorempixel.com/\(width)/\(height)"
-  }
+    public func freeEmail() -> String {
+      return [username(), generate("internet.free_email")].joined(separator: "@")
+    }
 
-  public func templateImage(width: Int = 320, height: Int = 200,
-                            backColorHex: String = "000000", frontColorHex: String = "ffffff") -> String {
+    public func safeEmail() -> String {
+      let topLevelDomains = ["org", "com", "net"]
+      #if swift(>=4.2)
+      let topLevelDomain = topLevelDomains.randomElement() ?? ""
+      #else
+      let count = UInt32(topLevelDomains.count)
+      let topLevelDomain = topLevelDomains[Int(arc4random_uniform(count))]
+      #endif
+
+      return [username(), "example." + topLevelDomain].joined(separator: "@")
+    }
+
+    public func password(minimumLength: Int = 8, maximumLength: Int = 16) -> String {
+      var temp = lorem.characters(amount: minimumLength)
+      let diffLength = maximumLength - minimumLength
+
+      if diffLength > 0 {
+        #if swift(>=4.2)
+        let diffRandom = Int.random(in: 0..<diffLength + 1)
+        #else
+        let diffRandom = Int(arc4random_uniform(UInt32(diffLength + 1)))
+        #endif
+        temp += lorem.characters(amount: diffRandom)
+      }
+
+      return temp
+    }
+
+    public func ipV4Address() -> String {
+      #if swift(>=4.2)
+      let randomNumber = UInt32.random(in: 0..<UInt32.max) % 253
+      #else
+      let randomNumber = arc4random() % 253
+      #endif
+      let ipRand = {
+        2 + randomNumber
+      }
+
+      return String(format: "%d.%d.%d.%d", ipRand(), ipRand(), ipRand(), ipRand())
+    }
+
+    public func ipV6Address() -> String {
+      #if swift(>=4.2)
+      let randomNumber = UInt32.random(in: 0..<UInt32.max) % 65536
+      #else
+      let randomNumber = arc4random() % 65536
+      #endif
+
+      var components: [String] = []
+
+      for _ in 0..<8 {
+        components.append(String(format: "%X", randomNumber))
+      }
+
+      return components.joined(separator: ":")
+    }
+
+    public func url() -> String {
+      return "https://\(domainName())/\(username())"
+    }
+
+    public func image(width: Int = 320, height: Int = 200) -> String {
+      return "https://lorempixel.com/\(width)/\(height)"
+    }
+
+    public func templateImage(width: Int = 320, height: Int = 200,
+                              backColorHex: String = "000000", frontColorHex: String = "ffffff") -> String {
       return "https://dummyimage.com/\(width)x\(height)/\(backColorHex)/\(frontColorHex)"
-  }
+    }
 
-  public func hashtag() -> String {
-    return generate("internet.hashtag")
-  }
+    public func hashtag() -> String {
+      return generate("internet.hashtag")
+    }
 
-  // @ToDo - slug
+    // @ToDo - slug
+  }
 }

--- a/Sources/Fakery/Generators/Lorem.swift
+++ b/Sources/Fakery/Generators/Lorem.swift
@@ -1,69 +1,71 @@
 import Foundation
 
-public final class Lorem: Generator {
-  public func word() -> String {
-    return generate("lorem.words")
-  }
-
-  public func words(amount: Int = 3) -> String {
-    var words: [String] = []
-
-    for _ in 0..<amount {
-      words.append(word())
+extension Faker {
+  public final class Lorem: Generator {
+    public func word() -> String {
+      return generate("lorem.words")
     }
 
-    return words.joined(separator: " ")
-  }
+    public func words(amount: Int = 3) -> String {
+      var words: [String] = []
 
-  public func character() -> String {
-    return characters(amount: 1)
-  }
-
-  public func characters(amount: Int = 255) -> String {
-    var chars = ""
-
-    if amount > 0 {
       for _ in 0..<amount {
-        #if swift(>=4.2)
-          let char = Character(UnicodeScalar(Int.random(in: 0..<Int.max) % (122-97) + 97)!)
-        #else
-          let char = Character(UnicodeScalar(arc4random() % (122-97) + 97)!)
-        #endif
-        chars.append(char)
+        words.append(word())
       }
+
+      return words.joined(separator: " ")
     }
 
-    return chars
-  }
-
-  public func sentence(wordsAmount: Int = 4) -> String {
-    var sentence = words(amount: wordsAmount) + "."
-    sentence.replaceSubrange(sentence.startIndex...sentence.startIndex,
-                          with: String(sentence[sentence.startIndex]).capitalized)
-    return sentence
-  }
-
-  public func sentences(amount: Int = 3) -> String {
-    var sentences: [String] = []
-
-    for _ in 0..<amount {
-      sentences.append(sentence())
+    public func character() -> String {
+      return characters(amount: 1)
     }
 
-    return sentences.joined(separator: " ")
-  }
+    public func characters(amount: Int = 255) -> String {
+      var chars = ""
 
-  public func paragraph(sentencesAmount: Int = 3) -> String {
-    return sentences(amount: sentencesAmount)
-  }
+      if amount > 0 {
+        for _ in 0..<amount {
+          #if swift(>=4.2)
+          let char = Character(UnicodeScalar(Int.random(in: 0..<Int.max) % (122 - 97) + 97)!)
+          #else
+          let char = Character(UnicodeScalar(arc4random() % (122-97) + 97)!)
+          #endif
+          chars.append(char)
+        }
+      }
 
-  public func paragraphs(amount: Int = 3) -> String {
-    var paragraphs: [String] = []
-
-    for _ in 0..<amount {
-      paragraphs.append(paragraph())
+      return chars
     }
 
-    return paragraphs.joined(separator: "\n")
+    public func sentence(wordsAmount: Int = 4) -> String {
+      var sentence = words(amount: wordsAmount) + "."
+      sentence.replaceSubrange(sentence.startIndex...sentence.startIndex,
+                               with: String(sentence[sentence.startIndex]).capitalized)
+      return sentence
+    }
+
+    public func sentences(amount: Int = 3) -> String {
+      var sentences: [String] = []
+
+      for _ in 0..<amount {
+        sentences.append(sentence())
+      }
+
+      return sentences.joined(separator: " ")
+    }
+
+    public func paragraph(sentencesAmount: Int = 3) -> String {
+      return sentences(amount: sentencesAmount)
+    }
+
+    public func paragraphs(amount: Int = 3) -> String {
+      var paragraphs: [String] = []
+
+      for _ in 0..<amount {
+        paragraphs.append(paragraph())
+      }
+
+      return paragraphs.joined(separator: "\n")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Name.swift
+++ b/Sources/Fakery/Generators/Name.swift
@@ -1,27 +1,29 @@
-public final class Name: Generator {
-  public func name() -> String {
-    return generate("name.name")
-  }
+extension Faker {
+  public final class Name: Generator {
+    public func name() -> String {
+      return generate("name.name")
+    }
 
-  public func firstName() -> String {
-    return generate("name.first_name")
-  }
+    public func firstName() -> String {
+      return generate("name.first_name")
+    }
 
-  public func lastName() -> String {
-    return generate("name.last_name")
-  }
+    public func lastName() -> String {
+      return generate("name.last_name")
+    }
 
-  public func prefix() -> String {
-    return generate("name.prefix")
-  }
+    public func prefix() -> String {
+      return generate("name.prefix")
+    }
 
-  public func suffix() -> String {
-    return generate("name.suffix")
-  }
+    public func suffix() -> String {
+      return generate("name.suffix")
+    }
 
-  public func title() -> String {
-    return generate("name.title.descriptor") + " "
-      + generate("name.title.level") + " "
-      + generate("name.title.job")
+    public func title() -> String {
+      return generate("name.title.descriptor") + " "
+          + generate("name.title.level") + " "
+          + generate("name.title.job")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Number.swift
+++ b/Sources/Fakery/Generators/Number.swift
@@ -3,57 +3,60 @@ import Foundation
 import CoreGraphics
 #endif
 
-public final class Number {
-  fileprivate var lastUsedId: Int64 = 0
+extension Faker {
+  public final class Number {
+    fileprivate var lastUsedId: Int64 = 0
 
-  public func randomBool() -> Bool {
-    return randomInt() % 2 == 0
-  }
-
-  public func randomInt(min: Int = 0, max: Int = 1000) -> Int {
-    var i: Int = 0
-    #if swift(>=4.2)
-    i = Int.random(in: i..<Int.max)
-    #else
-    arc4random_buf(&i, MemoryLayout.size(ofValue: i))
-    i = i & Int.max // Make the number positive
-    #endif
-
-    if max >= 0 && max - Int.max >= min {
-      return min + i
+    public func randomBool() -> Bool {
+      return randomInt() % 2 == 0
     }
 
-    return min + (i % (max - min))
-  }
+    public func randomInt(min: Int = 0, max: Int = 1000) -> Int {
+      var i: Int = 0
+      #if swift(>=4.2)
+      i = Int.random(in: i..<Int.max)
+      #else
+      arc4random_buf(&i, MemoryLayout.size(ofValue: i))
+      i = i & Int.max // Make the number positive
+      #endif
 
-  public func randomFloat(min: Float = 0, max: Float = 1000) -> Float {
-    #if swift(>=4.2)
-    return (Float.random(in: 0..<Float.greatestFiniteMagnitude) / Float.greatestFiniteMagnitude) * (max - min) + min
-    #else
-    return (Float(arc4random()) / Float(UInt32.max)) * (max - min) + min
+      if max >= 0 && max - Int.max >= min {
+        return min + i
+      }
+
+      return min + (i % (max - min))
+    }
+
+    public func randomFloat(min: Float = 0, max: Float = 1000) -> Float {
+      #if swift(>=4.2)
+      return (Float.random(in: 0..<Float.greatestFiniteMagnitude) / Float.greatestFiniteMagnitude) * (max - min) + min
+      #else
+      return (Float(arc4random()) / Float(UInt32.max)) * (max - min) + min
+      #endif
+    }
+
+    #if !os(Linux)
+    public func randomCGFloat(min: CGFloat = 0, max: CGFloat = 1000) -> CGFloat {
+      return CGFloat(Float(arc4random()) / Float(UInt32.max)) * (max - min) + min
+    }
     #endif
-  }
-  #if !os(Linux)
-  public func randomCGFloat(min: CGFloat = 0, max: CGFloat = 1000) -> CGFloat {
-    return CGFloat(Float(arc4random()) / Float(UInt32.max)) * (max - min) + min
-  }
-  #endif
 
-  public func randomDouble(min: Double = 0, max: Double = 1000) -> Double {
-    #if swift(>=4.2)
-    return (Double.random(in: 0..<Double.greatestFiniteMagnitude) / Double.greatestFiniteMagnitude) * (max - min) + min
-    #else
-    return (Double(arc4random()) / Double(UInt32.max)) * (max - min) + min
-    #endif
-  }
+    public func randomDouble(min: Double = 0, max: Double = 1000) -> Double {
+      #if swift(>=4.2)
+      return (Double.random(in: 0..<Double.greatestFiniteMagnitude) / Double.greatestFiniteMagnitude) * (max - min) + min
+      #else
+      return (Double(arc4random()) / Double(UInt32.max)) * (max - min) + min
+      #endif
+    }
 
-  public func increasingUniqueId() -> Int {
-    #if os(Linux)
-    // increasing just by one on linux due to the lack of an method like OSAtomicIncrement64
-    lastUsedId += 1
-    #else
+    public func increasingUniqueId() -> Int {
+      #if os(Linux)
+      // increasing just by one on linux due to the lack of an method like OSAtomicIncrement64
+      lastUsedId += 1
+      #else
       OSAtomicIncrement64(&lastUsedId)
-    #endif
-    return Int(lastUsedId)
+      #endif
+      return Int(lastUsedId)
+    }
   }
 }

--- a/Sources/Fakery/Generators/PhoneNumber.swift
+++ b/Sources/Fakery/Generators/PhoneNumber.swift
@@ -1,34 +1,36 @@
-public final class PhoneNumber: Generator {
-  public func phoneNumber() -> String {
-    return numerify(generate("phone_number.formats"))
-  }
-
-  public func cellPhone() -> String {
-    return numerify(generate("cell_phone.formats"))
-  }
-
-  // US only
-  public func areaCode() -> String {
-    return generate("phone_number.area_code")
-  }
-
-  // US only
-  public func exchangeCode() -> String {
-    return generate("phone_number.exchange_code")
-  }
-
-  // US only
-  public func subscriberNumber() -> String {
-    return numerify("####")
-  }
-
-  public func numberExtension(_ length: Int) -> String {
-    var template = ""
-
-    for _ in 1...length {
-      template += "#"
+extension Faker {
+  public final class PhoneNumber: Generator {
+    public func phoneNumber() -> String {
+      return numerify(generate("phone_number.formats"))
     }
 
-    return numerify(template)
+    public func cellPhone() -> String {
+      return numerify(generate("cell_phone.formats"))
+    }
+
+    // US only
+    public func areaCode() -> String {
+      return generate("phone_number.area_code")
+    }
+
+    // US only
+    public func exchangeCode() -> String {
+      return generate("phone_number.exchange_code")
+    }
+
+    // US only
+    public func subscriberNumber() -> String {
+      return numerify("####")
+    }
+
+    public func numberExtension(_ length: Int) -> String {
+      var template = ""
+
+      for _ in 1...length {
+        template += "#"
+      }
+
+      return numerify(template)
+    }
   }
 }

--- a/Sources/Fakery/Generators/ProgrammingLanguage.swift
+++ b/Sources/Fakery/Generators/ProgrammingLanguage.swift
@@ -1,9 +1,11 @@
-public final class ProgrammingLanguage: Generator {
-  public func name() -> String {
-    return generate("programming_language.name")
-  }
-  
-  public func creator() -> String {
-    return generate("programming_language.creator")
+extension Faker {
+  public final class ProgrammingLanguage: Generator {
+    public func name() -> String {
+      return generate("programming_language.name")
+    }
+
+    public func creator() -> String {
+      return generate("programming_language.creator")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Team.swift
+++ b/Sources/Fakery/Generators/Team.swift
@@ -1,13 +1,15 @@
-public final class Team: Generator {
-  public func name() -> String {
-    return generate("team.name")
-  }
+extension Faker {
+  public final class Team: Generator {
+    public func name() -> String {
+      return generate("team.name")
+    }
 
-  public func creature() -> String {
-    return generate("team.creature")
-  }
+    public func creature() -> String {
+      return generate("team.creature")
+    }
 
-  public func state() -> String {
-    return generate("address.state").capitalized
+    public func state() -> String {
+      return generate("address.state").capitalized
+    }
   }
 }

--- a/Sources/Fakery/Generators/Vehicle.swift
+++ b/Sources/Fakery/Generators/Vehicle.swift
@@ -1,13 +1,15 @@
-public final class Vehicle: Generator {
-  public func manufacture() -> String {
-    return generate("vehicle.manufacture")
-  }
+extension Faker {
+  public final class Vehicle: Generator {
+    public func manufacture() -> String {
+      return generate("vehicle.manufacture")
+    }
 
-  public func make() -> String {
-    return generate("vehicle.makes")
-  }
-  
-  public func colors() -> String {
-    return generate("vehicle.colors")
+    public func make() -> String {
+      return generate("vehicle.makes")
+    }
+
+    public func colors() -> String {
+      return generate("vehicle.colors")
+    }
   }
 }

--- a/Sources/Fakery/Generators/Zelda.swift
+++ b/Sources/Fakery/Generators/Zelda.swift
@@ -1,5 +1,7 @@
-public final class Zelda: Generator {
-  public func game() -> String {
-    return generate("zelda.game")
+extension Faker {
+  public final class Zelda: Generator {
+    public func game() -> String {
+      return generate("zelda.game")
+    }
   }
 }

--- a/Tests/Fakery/FakerSpec.swift
+++ b/Tests/Fakery/FakerSpec.swift
@@ -36,79 +36,79 @@ final class FakerSpec: QuickSpec {
 
       describe("#address") {
         it("should be accessible") {
-          expect(faker.address).to(beAKindOf(Address.self))
+          expect(faker.address).to(beAKindOf(Faker.Address.self))
         }
       }
 
       describe("#app") {
         it("should be accessible") {
-          expect(faker.app).to(beAKindOf(App.self))
+          expect(faker.app).to(beAKindOf(Faker.App.self))
         }
       }
 
       describe("#zelda") {
         it("should be accessible") {
-          expect(faker.zelda).to(beAKindOf(Zelda.self))
+          expect(faker.zelda).to(beAKindOf(Faker.Zelda.self))
         }
       }
 
       describe("#business") {
         it("should be accessible") {
-          expect(faker.business).to(beAKindOf(Business.self))
+          expect(faker.business).to(beAKindOf(Faker.Business.self))
         }
       }
 
       describe("#commerce") {
         it("should be accessible") {
-          expect(faker.commerce).to(beAKindOf(Commerce.self))
+          expect(faker.commerce).to(beAKindOf(Faker.Commerce.self))
         }
       }
       
       describe("#gender") {
         it("should be accessible") {
-          expect(faker.gender).to(beAKindOf(Gender.self))
+          expect(faker.gender).to(beAKindOf(Faker.Gender.self))
         }
       }
 
       describe("#internet") {
         it("should be accessible") {
-          expect(faker.internet).to(beAKindOf(Internet.self))
+          expect(faker.internet).to(beAKindOf(Faker.Internet.self))
         }
       }
 
       describe("#lorem") {
         it("should be accessible") {
-          expect(faker.lorem).to(beAKindOf(Lorem.self))
+          expect(faker.lorem).to(beAKindOf(Faker.Lorem.self))
         }
       }
 
       describe("#name") {
         it("should be accessible") {
-          expect(faker.name).to(beAKindOf(Name.self))
+          expect(faker.name).to(beAKindOf(Faker.Name.self))
         }
       }
 
       describe("#phoneNumber") {
         it("should be accessible") {
-          expect(faker.phoneNumber).to(beAKindOf(PhoneNumber.self))
+          expect(faker.phoneNumber).to(beAKindOf(Faker.PhoneNumber.self))
         }
       }
 
       describe("#team") {
         it("should be accessible") {
-          expect(faker.team).to(beAKindOf(Team.self))
+          expect(faker.team).to(beAKindOf(Faker.Team.self))
         }
       }
 
       describe("#bank") {
         it("should be accessible") {
-          expect(faker.bank).to(beAKindOf(Bank.self))
+          expect(faker.bank).to(beAKindOf(Faker.Bank.self))
         }
       }
 
       describe("#programmingLanguage") {
         it("should be accessible") {
-          expect(faker.programmingLanguage).to(beAKindOf(ProgrammingLanguage.self))
+          expect(faker.programmingLanguage).to(beAKindOf(Faker.ProgrammingLanguage.self))
         }
       }
     }

--- a/Tests/Fakery/Generators/AddressSpec.swift
+++ b/Tests/Fakery/Generators/AddressSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class AddressSpec: QuickSpec {
   override func spec() {
     describe("Address") {
-      var address: Address!
+      var address: Faker.Address!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        address = Address(parser: parser)
+        address = Faker.Address(parser: parser)
       }
 
       describe("#city") {

--- a/Tests/Fakery/Generators/AppSpec.swift
+++ b/Tests/Fakery/Generators/AppSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class AppSpec: QuickSpec {
   override func spec() {
     describe("App") {
-      var app: App!
+      var app: Faker.App!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        app = App(parser: parser)
+        app = Faker.App(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/BankSpec.swift
+++ b/Tests/Fakery/Generators/BankSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class BankSpec: QuickSpec {
   override func spec() {
     describe("Bank") {
-      var bank: Bank!
+      var bank: Faker.Bank!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        bank = Bank(parser: parser)
+        bank = Faker.Bank(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/BusinessSpec.swift
+++ b/Tests/Fakery/Generators/BusinessSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class BusinessSpec: QuickSpec {
   override func spec() {
     describe("Business") {
-      var business: Business!
+      var business: Faker.Business!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        business = Business(parser: parser)
+        business = Faker.Business(parser: parser)
       }
 
       describe("#creditCardNumber") {

--- a/Tests/Fakery/Generators/CarSpec.swift
+++ b/Tests/Fakery/Generators/CarSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class CarSpec: QuickSpec {
   override func spec() {
     describe("Car") {
-      var cars: Car!
+      var cars: Faker.Car!
       
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        cars = Car(parser: parser)
+        cars = Faker.Car(parser: parser)
       }
       
       describe("#brand") {

--- a/Tests/Fakery/Generators/CatSpec.swift
+++ b/Tests/Fakery/Generators/CatSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class CatSpec: QuickSpec {
   override func spec() {
     describe("Cat") {
-      var cat: Cat!
+      var cat: Faker.Cat!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        cat = Cat(parser: parser)
+        cat = Faker.Cat(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/CommerceSpec.swift
+++ b/Tests/Fakery/Generators/CommerceSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class CommerceSpec: QuickSpec {
   override func spec() {
     describe("Commerce") {
-      var commerce: Commerce!
+      var commerce: Faker.Commerce!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        commerce = Commerce(parser: parser)
+        commerce = Faker.Commerce(parser: parser)
       }
 
       describe("#color") {

--- a/Tests/Fakery/Generators/CompanySpec.swift
+++ b/Tests/Fakery/Generators/CompanySpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class CompanySpec: QuickSpec {
   override func spec() {
     describe("Company") {
-      var company: Company!
+      var company: Faker.Company!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        company = Company(parser: parser)
+        company = Faker.Company(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/DateSpec.swift
+++ b/Tests/Fakery/Generators/DateSpec.swift
@@ -6,10 +6,10 @@ import Foundation
 final class DateSpec: QuickSpec {
   override func spec() {
     describe("Date") {
-      var date: Fakery.Date!
+      var date: Faker.Date!
 
       beforeEach {
-        date = Date()
+        date = Faker.Date()
       }
 
       describe("#between") {

--- a/Tests/Fakery/Generators/GenderSpec.swift
+++ b/Tests/Fakery/Generators/GenderSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class GenderSpec: QuickSpec {
   override func spec() {
     describe("Gender") {
-      var gender: Gender!
+      var gender: Faker.Gender!
       
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        gender = Gender(parser: parser)
+        gender = Faker.Gender(parser: parser)
       }
       
       describe("#type") {

--- a/Tests/Fakery/Generators/GeneratorSpec.swift
+++ b/Tests/Fakery/Generators/GeneratorSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class GeneratorSpec: QuickSpec {
   override func spec() {
     describe("Generator") {
-      var generator: Generator!
+      var generator: Faker.Generator!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        generator = Generator(parser: parser)
+        generator = Faker.Generator(parser: parser)
       }
 
       it("has parser") {

--- a/Tests/Fakery/Generators/HamSpec.swift
+++ b/Tests/Fakery/Generators/HamSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class HamSpec: QuickSpec {
   override func spec() {
     describe("Ham") {
-      var ham: Ham!
+      var ham: Faker.Ham!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        ham = Ham(parser: parser)
+        ham = Faker.Ham(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/InternetSpec.swift
+++ b/Tests/Fakery/Generators/InternetSpec.swift
@@ -6,11 +6,11 @@ final class InternetSpec: QuickSpec {
   override func spec() {
     describe("Internet") {
       let emailFormat = "[\\w._%+-]+@[\\w.-]+\\.\\w{2,}"
-      var internet: Internet!
+      var internet: Faker.Internet!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        internet = Internet(parser: parser)
+        internet = Faker.Internet(parser: parser)
       }
 
       describe("#username") {

--- a/Tests/Fakery/Generators/LoremSpec.swift
+++ b/Tests/Fakery/Generators/LoremSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class LoremSpec: QuickSpec {
   override func spec() {
     describe("Lorem") {
-      var lorem: Lorem!
+      var lorem: Faker.Lorem!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        lorem = Lorem(parser: parser)
+        lorem = Faker.Lorem(parser: parser)
       }
 
       describe("#word") {

--- a/Tests/Fakery/Generators/NameSpec.swift
+++ b/Tests/Fakery/Generators/NameSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class NameSpec: QuickSpec {
   override func spec() {
     describe("Name") {
-      var name: Name!
+      var name: Faker.Name!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        name = Name(parser: parser)
+        name = Faker.Name(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/NumberSpec.swift
+++ b/Tests/Fakery/Generators/NumberSpec.swift
@@ -5,10 +5,10 @@ import Nimble
 final class NumberSpec: QuickSpec {
   override func spec() {
     describe("Number") {
-      var number: Number!
+      var number: Faker.Number!
 
       beforeEach {
-        number = Number()
+        number = Faker.Number()
       }
 
       it("creates contionusly increasing ids") {

--- a/Tests/Fakery/Generators/PhoneNumberSpec.swift
+++ b/Tests/Fakery/Generators/PhoneNumberSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class PhoneNumberSpec: QuickSpec {
   override func spec() {
     describe("PhoneNumber") {
-      var phoneNumber: PhoneNumber!
+      var phoneNumber: Faker.PhoneNumber!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        phoneNumber = PhoneNumber(parser: parser)
+        phoneNumber = Faker.PhoneNumber(parser: parser)
       }
 
       describe("#phoneNumber") {

--- a/Tests/Fakery/Generators/ProgrammingLanguageSpec.swift
+++ b/Tests/Fakery/Generators/ProgrammingLanguageSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class ProgrammingLanguageSpec: QuickSpec {
   override func spec() {
     describe("Programming Language") {
-      var language: ProgrammingLanguage!
+      var language: Faker.ProgrammingLanguage!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        language = ProgrammingLanguage(parser: parser)
+        language = Faker.ProgrammingLanguage(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/TeamSpec.swift
+++ b/Tests/Fakery/Generators/TeamSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class TeamSpec: QuickSpec {
   override func spec() {
     describe("Team") {
-      var team: Team!
+      var team: Faker.Team!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        team = Team(parser: parser)
+        team = Faker.Team(parser: parser)
       }
 
       describe("#name") {

--- a/Tests/Fakery/Generators/VehicleSpec.swift
+++ b/Tests/Fakery/Generators/VehicleSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class VehicleSpec: QuickSpec {
   override func spec() {
     describe("Vehicle") {
-      var vehicle: Vehicle!
+      var vehicle: Faker.Vehicle!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        vehicle = Vehicle(parser: parser)
+        vehicle = Faker.Vehicle(parser: parser)
       }
 
       describe("#manufacture") {

--- a/Tests/Fakery/Generators/ZeldaSpec.swift
+++ b/Tests/Fakery/Generators/ZeldaSpec.swift
@@ -5,11 +5,11 @@ import Nimble
 final class ZeldaSpec: QuickSpec {
   override func spec() {
     describe("Zelda") {
-      var zelda: Zelda!
+      var zelda: Faker.Zelda!
 
       beforeEach {
         let parser = Parser(locale: "en-TEST")
-        zelda = Zelda(parser: parser)
+        zelda = Faker.Zelda(parser: parser)
       }
 
       describe("#game") {


### PR DESCRIPTION
When Fakery is imported, Xcode sees to implementations of Date and gets confused. This can happen also if you inport your own target, .e.g some Model target, which defines type similar to one of generators, e.g. Address. To avoid this kind of issues, all generators now have a namespace Faker