### PR TITLE
Fix Date and Number could not use

### DIFF
--- a/Sources/Fakery/Generators/Date.swift
+++ b/Sources/Fakery/Generators/Date.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Faker {
-  public final class Date {
+  public final class Date: Generator {
     public func backward(days: Int) -> Foundation.Date {
       return todayAddingDays(-days)
     }

--- a/Sources/Fakery/Generators/Generator.swift
+++ b/Sources/Fakery/Generators/Generator.swift
@@ -12,7 +12,7 @@ extension Faker {
     let parser: Parser
     let dateFormatter: DateFormatter
 
-    public required init(parser: Parser) {
+    public required init(parser: Parser = Parser()) {
       self.parser = parser
       dateFormatter = DateFormatter()
       dateFormatter.dateFormat = "yyyy-MM-dd"

--- a/Sources/Fakery/Generators/Number.swift
+++ b/Sources/Fakery/Generators/Number.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 #endif
 
 extension Faker {
-  public final class Number {
+  public final class Number: Generator {
     fileprivate var lastUsedId: Int64 = 0
 
     public func randomBool() -> Bool {


### PR DESCRIPTION
Initializer of Date and Number is internal scope, so we could not use them now.
The PR become to be able to use Date and Number.

I added the default value to Generator's initalizer because some classes do not need parser.