### PR TITLE
[Fix] Update dependencies to fix building on XCode 12.4 and 12.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
-          "version": "8.1.2"
+          "revision": "e491a6731307bb23783bf664d003be9b2fa59ab5",
+          "version": "9.0.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
-          "version": "2.2.1"
+          "revision": "8a10ae40b78d2360ca56638f15fe721be8529993",
+          "version": "3.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
 
     ],
     targets: [
-      .target(name: "Fakery", resources: [.copy("Resources")]),
+      .target(name: "Fakery", resources: [.process("Resources")]),
       .testTarget(name: "FakeryTests", dependencies: ["Fakery","Quick", "Nimble"], path: "Tests/Fakery")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
     // Test dependencies
     .package(url: "https://github.com/Quick/Quick.git", from: "2.0.0"),
-    .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
+    .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
 
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
     // Test dependencies
-    .package(url: "https://github.com/Quick/Quick.git", from: "2.0.0"),
+    .package(url: "https://github.com/Quick/Quick.git", from: "3.1.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
 
     ],


### PR DESCRIPTION
Closes #143 

I am not the author of these changes, however I thought it might be useful to merge these changes so this library can be used  on XCode 12.4 and 12.5. 
Tested by me, works as expected.