### PR TITLE
Set iOS deployment target to 9.0 on pbxproj

### DIFF
--- a/Fakery.xcodeproj/project.pbxproj
+++ b/Fakery.xcodeproj/project.pbxproj
@@ -1386,6 +1386,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Project/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1410,6 +1411,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Project/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
Hi

I use this lib thought `Carthage`, but once I updated from version 5.0.0 to 5.1.0 I noticed that the minimum deployment target has changed.

---

This PR sets it to version 9.0, the same defined in the `Package.swift` file.