### PR TITLE
Support seeded random number generators

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "682841464136f8c66e04afe5dbd01ab51a3a56f2",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
+          "version": "2.0.0"
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
@@ -15,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "8a10ae40b78d2360ca56638f15fe721be8529993",
-          "version": "3.1.0"
+          "revision": "8cce6acd38f965f5baa3167b939f86500314022b",
+          "version": "3.1.2"
         }
       }
     ]

--- a/Sources/Fakery/Config.swift
+++ b/Sources/Fakery/Config.swift
@@ -4,4 +4,5 @@ public struct Config {
   public static var dirPath: String = "Resources/Locales"
   public static var dirFrameworkPath: String = ""
   public static var dirResourcePath: String = ""
+  public static var randomNumberGenerator = AnyRandomNumberGenerator(SystemRandomNumberGenerator())
 }

--- a/Sources/Fakery/Data/Parser.swift
+++ b/Sources/Fakery/Data/Parser.swift
@@ -11,11 +11,17 @@ public final class Parser {
 
   private var data = [String: Any]()
   let provider: Provider
-
+  var randomNumberGenerator: AnyRandomNumberGenerator
+  
   // MARK: - Initialization
 
-  public init(locale: String = Config.defaultLocale) {
+  public init(
+    locale: String = Config.defaultLocale,
+    randomNumberGenerator: AnyRandomNumberGenerator = Config.randomNumberGenerator
+  ) {
     self.locale = locale
+    self.randomNumberGenerator = randomNumberGenerator
+    
     provider = Provider()
     loadData(forLocale: locale)
 
@@ -37,7 +43,7 @@ public final class Parser {
 
     if let value = keyData as? String {
       parsed = value
-    } else if let array = keyData as? [String], let item = array.random() {
+    } else if let array = keyData as? [String], let item = array.random(using: &randomNumberGenerator) {
       parsed = item
     }
 

--- a/Sources/Fakery/Data/Random.swift
+++ b/Sources/Fakery/Data/Random.swift
@@ -1,0 +1,14 @@
+
+import Foundation
+
+public struct AnyRandomNumberGenerator: RandomNumberGenerator {
+    var wrapped: RandomNumberGenerator
+
+    public init<T: RandomNumberGenerator>(_ wrapped: T) {
+        self.wrapped = wrapped
+    }
+    
+    public mutating func next() -> UInt64 {
+        wrapped.next()
+    }
+}

--- a/Sources/Fakery/Extensions/ArrayExtension.swift
+++ b/Sources/Fakery/Extensions/ArrayExtension.swift
@@ -9,15 +9,15 @@ extension Array {
     return self[index]
   }
 
-  func random() -> Element? {
+    func random<T: RandomNumberGenerator>(using generator: inout T) -> Element? {
     // swiftlint:disable empty_count
     guard count > 0 else {
       return nil
     }
     #if swift(>=4.2)
-      return self.randomElement()
+      return self.randomElement(using: &generator)
     #else
-     return self[Int(arc4random_uniform(UInt32(count)))]
+      return self[Int.random(in: 0..<count, using: &generator)]
     #endif
   }
 }

--- a/Sources/Fakery/Faker.swift
+++ b/Sources/Fakery/Faker.swift
@@ -34,30 +34,38 @@ public final class Faker {
 
   // MARK: - Initialization
 
-  public init(locale: String = Config.defaultLocale) {
+  public convenience init(locale: String = Config.defaultLocale) {
+    self.init(locale: locale, randomNumberGenerator: Config.randomNumberGenerator)
+  }
+    
+  public init<T: RandomNumberGenerator>(
+    locale: String = Config.defaultLocale,
+    randomNumberGenerator: T
+  ) {
     self.locale = locale
-    parser = Parser(locale: self.locale)
-    address = Address(parser: parser)
-    app = App(parser: parser)
-    zelda = Zelda(parser: parser)
-    business = Business(parser: parser)
-    cat = Cat(parser: parser)
-    company = Company(parser: parser)
-    commerce = Commerce(parser: parser)
-    gender = Gender(parser: parser)
-    internet = Internet(parser: parser)
-    lorem = Lorem(parser: parser)
-    name = Name(parser: parser)
-    phoneNumber = PhoneNumber(parser: parser)
-    team = Team(parser: parser)
-    number = Number()
-    bank = Bank(parser: parser)
-    date = Date()
-    hobbit = Hobbit(parser: parser)
-    car = Car(parser: parser)
-    programmingLanguage = ProgrammingLanguage(parser: parser)
-    vehicle = Vehicle(parser: parser)
-    ham = Ham(parser: parser)
-    house = House(parser: parser)
+    let typeErasedRandomNumberGenerator = AnyRandomNumberGenerator(randomNumberGenerator)
+    parser = Parser(locale: self.locale, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    address = Address(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    app = App(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    zelda = Zelda(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    business = Business(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    cat = Cat(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    company = Company(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    commerce = Commerce(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    gender = Gender(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    internet = Internet(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    lorem = Lorem(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    name = Name(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    phoneNumber = PhoneNumber(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    team = Team(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    number = Number(randomNumberGenerator: typeErasedRandomNumberGenerator)
+    bank = Bank(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    date = Date(randomNumberGenerator: typeErasedRandomNumberGenerator)
+    hobbit = Hobbit(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    car = Car(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    programmingLanguage = ProgrammingLanguage(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    vehicle = Vehicle(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    ham = Ham(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
+    house = House(parser: parser, randomNumberGenerator: typeErasedRandomNumberGenerator)
   }
 }

--- a/Sources/Fakery/Generators/Date.swift
+++ b/Sources/Fakery/Generators/Date.swift
@@ -13,7 +13,7 @@ extension Faker {
     public func between(_ from: Foundation.Date, _ to: Foundation.Date) -> Foundation.Date {
       let fromInSeconds = from.timeIntervalSince1970
       let toInSeconds = to.timeIntervalSince1970
-      let targetInSeconds = Number().randomDouble(min: fromInSeconds, max: toInSeconds)
+      let targetInSeconds = Number(randomNumberGenerator: randomNumberGenerator).randomDouble(min: fromInSeconds, max: toInSeconds)
       return Foundation.Date(timeIntervalSince1970: targetInSeconds)
     }
 

--- a/Sources/Fakery/Generators/Generator.swift
+++ b/Sources/Fakery/Generators/Generator.swift
@@ -11,9 +11,14 @@ extension Faker {
 
     let parser: Parser
     let dateFormatter: DateFormatter
-
-    public required init(parser: Parser = Parser()) {
+    var randomNumberGenerator: AnyRandomNumberGenerator
+    
+    public required init(
+      parser: Parser = Parser(),
+      randomNumberGenerator: AnyRandomNumberGenerator = Config.randomNumberGenerator
+    ) {
       self.parser = parser
+      self.randomNumberGenerator = randomNumberGenerator
       dateFormatter = DateFormatter()
       dateFormatter.dateFormat = "yyyy-MM-dd"
     }
@@ -67,7 +72,7 @@ extension Faker {
       var list = [String]()
       if let wordsList = parser.fetchRaw(key) as? [[String]] {
         for words in wordsList {
-          if let item = words.random() {
+          if let item = words.random(using: &randomNumberGenerator) {
             list.append(item)
           }
         }

--- a/Sources/Fakery/Generators/Internet.swift
+++ b/Sources/Fakery/Generators/Internet.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension Faker {
   public final class Internet: Generator {
-    public required init(parser: Parser) {
-      super.init(parser: parser)
+    public required init(parser: Parser, randomNumberGenerator: AnyRandomNumberGenerator = Config.randomNumberGenerator) {
+      super.init(parser: parser, randomNumberGenerator: randomNumberGenerator)
     }
 
     public func username(separator: String? = nil) -> String {

--- a/Sources/Fakery/Generators/Number.swift
+++ b/Sources/Fakery/Generators/Number.swift
@@ -8,13 +8,13 @@ extension Faker {
     fileprivate var lastUsedId: Int64 = 0
 
     public func randomBool() -> Bool {
-      return randomInt() % 2 == 0
+      return Bool.random(using: &randomNumberGenerator)
     }
 
     public func randomInt(min: Int = 0, max: Int = 1000) -> Int {
       var rand: Int = 0
       #if swift(>=4.2)
-      rand = Int.random(in: rand..<Int.max)
+      rand = Int.random(in: rand..<Int.max, using: &randomNumberGenerator)
       #else
       arc4random_buf(&rand, MemoryLayout.size(ofValue: rand))
       rand = rand & Int.max // Make the number positive
@@ -29,7 +29,7 @@ extension Faker {
 
     public func randomFloat(min: Float = 0, max: Float = 1000) -> Float {
       #if swift(>=4.2)
-      return (Float.random(in: 0..<Float.greatestFiniteMagnitude) / Float.greatestFiniteMagnitude) * (max - min) + min
+      return (Float.random(in: 0..<Float.greatestFiniteMagnitude, using: &randomNumberGenerator) / Float.greatestFiniteMagnitude) * (max - min) + min
       #else
       return (Float(arc4random()) / Float(UInt32.max)) * (max - min) + min
       #endif
@@ -43,7 +43,7 @@ extension Faker {
 
     public func randomDouble(min: Double = 0, max: Double = 1000) -> Double {
       #if swift(>=4.2)
-      return (Double.random(in: 0..<Double.greatestFiniteMagnitude) / Double.greatestFiniteMagnitude)
+      return (Double.random(in: 0..<Double.greatestFiniteMagnitude, using: &randomNumberGenerator) / Double.greatestFiniteMagnitude)
         * (max - min) + min
       #else
       return (Double(arc4random()) / Double(UInt32.max)) * (max - min) + min


### PR DESCRIPTION
Hi!

I've added support for seeded RNG by allowing the passing of any `RandomNumberGenerator` to `Faker`.

Caveats:
- I ignored Swift <= 4.2. It might not compile with the older swift versions; if it does, it won't used the RNG that was passed in. Not sure if dropping support for 4.2 is an option at this point.
- I didn't write a unit test (I'm not familiar with QuickSpec and don't have more time to spend on this right now).

That being said, you can use this like this:

`let faker = Faker(randomNumberGenerator: SomeAdvancedRandomNumberGenerator())`

Unfortunately, seeded RNG is somewhat hidden in iOS; my first idea was to use the RNG provided by GameKit:

     import GameKit
    
     extension GKMersenneTwisterRandomSource: RandomNumberGenerator {}
     let faker = Faker(randomNumberGenerator: GKMersenneTwisterRandomSource(seed: 42))

We need to make `GKMersenneTwisterRandomSource` conform to `RandomNumberGenerator`, which is fortunately quite easy. We can then use it as the seeded RNG.

However, this requires that GameKit is available. In the end, I didn't want introduce a GameKit dependency, and the whole thing is overkill anyway for my testing purposes, so I implemented a custom "RNG" which works fine for my case:

    public class AdvancedRandomNumberGenerator: RandomNumberGenerator {
        var currentIndex = 0
        
        // chosen by fair dice roll
        // guaranteed to be random
        lazy var randomValues: [UInt64] = [4151371853236615391, 7134936793715064765, 8637388537612094686, ...]
        
        public func next() -> UInt64 {
            currentIndex += 1
            return randomValues[currentIndex % randomValues.count]
        }
    }
