### PR TITLE
mac catalyst compatibility improved

### DIFF
--- a/Fakery.podspec
+++ b/Fakery.podspec
@@ -23,9 +23,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   s.requires_arc = true
 
-  s.resource_bundles = {
-    'Faker' => ['Sources/Fakery/Resources/Locales/*.{json}']
-  }
+  s.resources = 'Sources/Fakery/Resources/Locales/*.{json}'
 
   s.source_files = 'Sources/**/*.{swift}'
   s.frameworks = 'Foundation'


### PR DESCRIPTION
The resources need to implemented that way on the .podspec because using the current configuration, you get the following error when you try to upload a mac catalyst app to the App Store Connect:

```
ITMS-90284: Invalid Code Signing - The executable 'Foo.app/Contents/Frameworks/Fakery.framework/Versions/A/Resources/Faker.bundle' must be signed with the certificate that is contained in the provisioning profile.
```