### PR TITLE
Fix hobbit values wrongly nested in array

### DIFF
--- a/Sources/Fakery/Resources/Locales/en.json
+++ b/Sources/Fakery/Resources/Locales/en.json
@@ -11357,7 +11357,7 @@
             "zelda": {
                 "game": ["A Link to the Past", "Breath of the Wild", "Four Swords", "Link's Awakening", "Majora's Mask", "Ocarina of Time", "Oracle of Seasons - Oracle of Ages", "Phantom Hourglass", "The Legend of Zelda", "The Minish Cap", "The Wind Waker", "Twilight Princess", "Zelda II: Adventure of Link"]
             },
-            "hobbit": [{
+            "hobbit": {
                 "character": [
                     "Bilbo Baggins",
                     "Bungo Baggins",
@@ -11467,7 +11467,7 @@
                     "Iron Hills",
                     "Mount Gundabad"
                 ]
-            }],
+            },
             "house": {
                 "furniture": [
                     "chair",


### PR DESCRIPTION
When using `Faker().hobbit.quote()` or any other the other `hobbit` categories a empty string `""` would always be returned, this was because the parser was failing to traverse the dictionary as the nested element within `hobbit` was an `Array<Dictionary<String: Any>>` and should just been `Dictionary<String: Any>`